### PR TITLE
adapt column number in main panel if unset entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ You can also use YAML:
 
 ```yaml
 type: custom:solar-card
-# Left panel
-production_entity: sensor.pv_production_now            # W or kW
-current_consumption_entity: sensor.house_consumption    # W or kW
+# Left panel (required)
+production_entity: sensor.pv_production_now            # W or kW (required)
+current_consumption_entity: sensor.house_consumption    # W or kW (required)
 image_url: https://example.com/your/solar.jpg          # optional
 
-# Today (top-right)
-yield_today_entity: sensor.pv_yield_today               # kWh (optional)
-grid_consumption_today_entity: sensor.grid_today        # kWh (optional)
-battery_percentage_entity: sensor.battery_soc           # %
-inverter_state_entity: sensor.inverter_state            # text
+# Today (top-right) — optional; metrics render only when configured or derivable
+yield_today_entity: sensor.pv_yield_today               # kWh (optional; or derive from total_yield)
+grid_consumption_today_entity: sensor.grid_today        # kWh (optional; or derive from total_grid_consumption)
+battery_percentage_entity: sensor.battery_soc           # % (optional)
+inverter_state_entity: sensor.inverter_state            # text (optional)
 
 # Totals (bottom-right)
 total_yield_entity: sensor.pv_total_yield               # kWh
@@ -87,7 +87,8 @@ solar_forecast_today_entity: sensor.solar_forecast_today # optional (shows forec
 ```
 
 Notes:
-- If `yield_today_entity` or `grid_consumption_today_entity` are not set (or unavailable), the card will compute today’s value from their respective totals using the history API.
+- The left panel requires both production and current consumption entities.
+- The Today section is optional. Each metric shows only if its entity is configured; for Yield/Grid it can also show if the corresponding total is set (derived via history since midnight).
 - The devices row uses Energy preferences → “Individual devices” and will show devices currently consuming power based on associated power sensors.
 - The Energy Flow section requires that your Energy dashboard is configured.
 

--- a/src/solar-card-editor.ts
+++ b/src/solar-card-editor.ts
@@ -51,8 +51,8 @@ export class HaSolarCardEditor extends LitElement {
   _buildSchemas() {
     const cfg = this.config || {};
     const overview = [
-      { name: 'production_entity', selector: { entity: { domain: 'sensor', device_class: 'power' } } },
-      { name: 'current_consumption_entity', selector: { entity: { domain: 'sensor', device_class: 'power' } } },
+      { name: 'production_entity', required: true, selector: { entity: { domain: 'sensor', device_class: 'power' } } },
+      { name: 'current_consumption_entity', required: true, selector: { entity: { domain: 'sensor', device_class: 'power' } } },
       { name: 'image_url', selector: { text: {} } },
     ];
     const today = [


### PR DESCRIPTION
### Description

This PR makes the column number in the main panel adaptable to the configured entities. Now the panel can have 1, 2, 3 or 4 columns.

### Screenshots

<img width="1229" height="154" alt="Captura de pantalla 2025-09-05 a las 16 09 05" src="https://github.com/user-attachments/assets/5a3903f5-c451-4297-af5b-3f0956e3a5c5" />

### Related issues

Closes: https://github.com/victorigualada/lovelace-solar-card/issues/4
