### PR TITLE
fix alignement in overview panel metrics

### DIFF
--- a/src/solar-card.ts
+++ b/src/solar-card.ts
@@ -150,7 +150,6 @@ class HaSolarCard extends LitElement {
       color: var(--secondary-text-color);
     }
     .overview-panel .metric .value {
-      justify-self: end;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
## Description

This PR fixes bad alignement of the overview panel metrics for mobile screens

## Screenshots

Before: 
<img width="388" height="270" alt="imagen" src="https://github.com/user-attachments/assets/21b329c3-5da8-446d-bb2a-dc85e850b2ec" />


After:
<img width="383" height="215" alt="imagen" src="https://github.com/user-attachments/assets/7912ecdc-87d6-466b-89e0-12bffea07094" />
