### PR TITLE
replace fixed metric with optional custom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 
 - Left panel: production and current consumption with optional image/illustration
 - Today metrics: yield today, grid today, battery percentage, inverter state
-- Totals: lifetime yield, total grid consumption, battery capacity, inverter mode
+- Totals grid: lifetime yield, total grid consumption, battery capacity, inverter mode
+- Custom totals metrics: add up to 8 extra entities with friendly labels
+- Drag-and-drop ordering: reorder custom metrics directly in the visual editor
 - Optional devices row: lists top consuming devices (from Energy preferences)
 - Optional energy flow: embeds the built‑in Energy Sankey card below
 - Optional compact forecast panel: weather or expected solar forecast
@@ -59,23 +61,22 @@ production_entity: sensor.pv_production_now # W or kW (required)
 current_consumption_entity: sensor.house_consumption # W or kW (required)
 image_url: https://example.com/your/solar.jpg # optional
 
-# Today (top-right) — optional; metrics render only when configured or derivable
-yield_today_entity: sensor.pv_yield_today # kWh (optional; or derive from total_yield)
-grid_consumption_today_entity: sensor.grid_today # kWh (optional; or derive from total_grid_consumption)
-battery_percentage_entity: sensor.battery_soc # % (optional)
-inverter_state_entity: sensor.inverter_state # text (optional)
-
-# Totals (bottom-right)
+# Totals (right panels)
 total_yield_entity: sensor.pv_total_yield # kWh
 total_grid_consumption_entity: sensor.grid_total # kWh
-battery_capacity_entity: sensor.battery_capacity # kWh (optional)
-inverter_mode_entity: sensor.inverter_mode # text
+# Optional custom metrics for the totals grid (up to 8 entries, supports drag & drop ordering)
+totals_metrics:
+  - entity: sensor.pv_total_yield
+    label: Total yield
+  - entity: sensor.grid_total
+    label: Grid consumption
+  - entity: sensor.battery_total_throughput
+    label: Battery throughput
 
 # Options
 show_energy_flow: true                                  # show built‑in Energy Sankey
 show_top_devices: true                                  # show devices row
 top_devices_max: 4                                      # 1–8
-grid_consumption_kwh_entity: sensor.grid_energy_daily   # optional single kWh tile (legacy)
 trend_graph_entities:                                   # optional list of tile trend graphs
   - sensor.grid_energy_daily
   - sensor.pv_yield_today
@@ -87,8 +88,9 @@ solar_forecast_today_entity: sensor.solar_forecast_today # optional (shows forec
 Notes:
 
 - The left panel requires both production and current consumption entities.
-- The Today section is optional. Each metric shows only if its entity is configured; for Yield/Grid it can also show if the corresponding total is set (derived via history since midnight).
-- If `trend_graph_entities` (or `grid_consumption_kwh_entity`) is set, the card renders one Tile per entity with the Tile "trend-graph" feature between the devices row and the Energy Sankey.
+- The Today section shows derived yield and grid consumption metrics automatically, and the totals grid flows onto additional rows after four items.
+- Custom totals metrics accept any label (spaces allowed) and the order you set in the editor is preserved in the card.
+- If `trend_graph_entities` is set, the card renders one Tile per entity with the Tile "trend-graph" feature between the devices row and the Energy Sankey.
 - The devices row uses Energy preferences → “Individual devices” and will show devices currently consuming power based on associated power sensors.
 - The Energy Flow section requires that your Energy dashboard is configured.
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@lit-labs/scoped-registry-mixin": "1.0.4",
     "custom-card-helpers": "1.9.0",
     "home-assistant-js-websocket": "9.5.0",
-    "lit": "3.3.1"
+    "lit": "3.3.1",
+    "@mdi/js": "7.4.47"
   },
   "devDependencies": {
     "@babel/core": "7.28.3",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -10,8 +10,20 @@
     "grid_consumption": "Netzverbrauch",
     "battery_capacity": "Batteriekapazität",
     "inverter_mode": "Wechselrichtermodus",
+    "total_metric": "Metrik",
     "weather_today": "Wetter heute",
     "solar_forecast": "Solarvorhersage",
     "expected_forecast": "Erwartete Vorhersage"
+  },
+  "editor": {
+    "metrics_using_defaults": "Verwendet derzeit die Standardwerte der Totals-Quellen. Beim Bearbeiten wird eine benutzerdefinierte Liste gespeichert.",
+    "metrics_empty": "Noch keine Metriken konfiguriert.",
+    "add_metric": "Metrik hinzufügen",
+    "metric_label": "Anzeigename (optional)",
+    "metric_entity": "Entität",
+    "metric_unit": "Einheit überschreiben (optional)",
+    "metric_icon": "Symbol (optional)",
+    "remove_metric": "Metrik entfernen",
+    "reorder_metric": "Metrik neu anordnen"
   }
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -16,8 +16,20 @@
     "grid_consumption": "Grid consumption",
     "battery_capacity": "Battery capacity",
     "inverter_mode": "Inverter mode",
+    "total_metric": "Metric",
     "weather_today": "Weather today",
     "solar_forecast": "Solar forecast",
     "expected_forecast": "Expected forecast"
+  },
+  "editor": {
+    "metrics_using_defaults": "Currently using defaults from totals data sources. Editing will save a custom list.",
+    "metrics_empty": "No metrics configured yet.",
+    "add_metric": "Add metric",
+    "metric_label": "Display label (optional)",
+    "metric_entity": "Entity",
+    "metric_unit": "Unit override (optional)",
+    "metric_icon": "Icon (optional)",
+    "remove_metric": "Remove metric",
+    "reorder_metric": "Reorder metric"
   }
 }

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -10,8 +10,20 @@
     "grid_consumption": "Consumo de red",
     "battery_capacity": "Capacidad de la batería",
     "inverter_mode": "Modo del inversor",
+    "total_metric": "Métrica",
     "weather_today": "Tiempo hoy",
     "solar_forecast": "Pronóstico solar",
     "expected_forecast": "Pronóstico esperado"
+  },
+  "editor": {
+    "metrics_using_defaults": "Actualmente se usan los valores predeterminados de las fuentes de totales. Al editar se guardará una lista personalizada.",
+    "metrics_empty": "Todavía no hay métricas configuradas.",
+    "add_metric": "Añadir métrica",
+    "metric_label": "Etiqueta mostrada (opcional)",
+    "metric_entity": "Entidad",
+    "metric_unit": "Unidad personalizada (opcional)",
+    "metric_icon": "Icono (opcional)",
+    "remove_metric": "Eliminar métrica",
+    "reorder_metric": "Reordenar métrica"
   }
 }

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -10,8 +10,20 @@
     "grid_consumption": "Consommation réseau",
     "battery_capacity": "Capacité de la batterie",
     "inverter_mode": "Mode de l'onduleur",
+    "total_metric": "Métrique",
     "weather_today": "Météo aujourd'hui",
     "solar_forecast": "Prévision solaire",
     "expected_forecast": "Prévision attendue"
+  },
+  "editor": {
+    "metrics_using_defaults": "Utilise actuellement les valeurs par défaut des sources de totaux. La modification enregistrera une liste personnalisée.",
+    "metrics_empty": "Aucune métrique configurée.",
+    "add_metric": "Ajouter une métrique",
+    "metric_label": "Libellé affiché (facultatif)",
+    "metric_entity": "Entité",
+    "metric_unit": "Unité personnalisée (facultatif)",
+    "metric_icon": "Icône (facultatif)",
+    "remove_metric": "Supprimer la métrique",
+    "reorder_metric": "Réordonner la métrique"
   }
 }

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -10,8 +10,20 @@
     "grid_consumption": "Netverbruik",
     "battery_capacity": "Batterijcapaciteit",
     "inverter_mode": "Omvormermodus",
+    "total_metric": "Metriek",
     "weather_today": "Weer vandaag",
     "solar_forecast": "Zonneprognose",
     "expected_forecast": "Verwachte prognose"
+  },
+  "editor": {
+    "metrics_using_defaults": "Gebruikt momenteel de standaardwaarden van de totale gegevensbronnen. Bewerken slaat een aangepaste lijst op.",
+    "metrics_empty": "Nog geen metrieken geconfigureerd.",
+    "add_metric": "Metriek toevoegen",
+    "metric_label": "Weergavelabel (optioneel)",
+    "metric_entity": "Entiteit",
+    "metric_unit": "Eenheid overschrijven (optioneel)",
+    "metric_icon": "Icoon (optioneel)",
+    "remove_metric": "Metriek verwijderen",
+    "reorder_metric": "Metriek opnieuw ordenen"
   }
 }

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -10,8 +10,20 @@
     "grid_consumption": "Consumo da rede",
     "battery_capacity": "Capacidade da bateria",
     "inverter_mode": "Modo do inversor",
+    "total_metric": "Métrica",
     "weather_today": "Tempo hoje",
     "solar_forecast": "Previsão solar",
     "expected_forecast": "Previsão esperada"
+  },
+  "editor": {
+    "metrics_using_defaults": "Atualmente usando padrões das fontes dos totais. Ao editar será guardada uma lista personalizada.",
+    "metrics_empty": "Nenhuma métrica configurada.",
+    "add_metric": "Adicionar métrica",
+    "metric_label": "Rótulo exibido (opcional)",
+    "metric_entity": "Entidade",
+    "metric_unit": "Unidade personalizada (opcional)",
+    "metric_icon": "Ícone (opcional)",
+    "remove_metric": "Remover métrica",
+    "reorder_metric": "Reordenar métrica"
   }
 }

--- a/src/solar-card-editor.ts
+++ b/src/solar-card-editor.ts
@@ -1,10 +1,20 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
+import { mdiDelete } from '@mdi/js';
 import type { Hass } from './types/ha';
-import type { SolarCardConfig } from './types/solar-card-config';
+import { localize } from './localize/localize';
+import type { SolarCardConfig, SolarCardTotalsMetric } from './types/solar-card-config';
 
 export class HaSolarCardEditor extends LitElement {
+  private static readonly MAX_METRICS = 6;
   private _hass: Hass | null;
   public config: SolarCardConfig;
+  private readonly _metricFormSchema = [
+    { name: 'entity', selector: { entity: {} } },
+    { name: 'label', selector: { text: {} } },
+    { name: 'unit', selector: { text: {} } },
+    { name: 'icon', selector: { icon: {} } },
+  ];
+  private _expandedMetricIds: Set<string>;
   static styles = css`
     .editor {
       padding: 8px 0;
@@ -27,6 +37,111 @@ export class HaSolarCardEditor extends LitElement {
     .dependent ha-form {
       margin-top: 4px;
     }
+    .metrics-editor {
+      display: grid;
+      gap: 12px;
+    }
+    .metrics-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .metrics-list {
+      display: grid;
+      gap: 12px;
+    }
+    .metric-item {
+      border: 1px solid var(--divider-color, #d3dce5);
+      border-radius: var(--ha-card-border-radius, 12px);
+      overflow: hidden;
+      background: var(--card-background-color, var(--ha-card-background, white));
+    }
+    .metrics-empty {
+      color: var(--secondary-text-color);
+      font-size: 0.9rem;
+    }
+    ha-expansion-panel.metric-item {
+      --expansion-panel-content-padding: 0;
+      --expansion-panel-summary-padding: 0;
+      --expansion-panel-border-color: var(--divider-color, #d3dce5);
+      --expansion-panel-border-radius: var(--ha-card-border-radius, 12px);
+    }
+    .metric-summary {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      gap: 12px;
+      padding: 4px 16px;
+    }
+    .metric-summary .metric-handle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+      border-radius: 6px;
+      color: var(--secondary-text-color);
+      cursor: grab;
+      flex: 0 0 auto;
+    }
+    .metric-summary .metric-handle:active {
+      cursor: grabbing;
+    }
+    .metric-summary .metric-handle ha-icon {
+      --mdc-icon-size: 20px;
+    }
+    .metric-summary .title {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+      gap: 12px;
+      width: 100%;
+      min-width: 0;
+      font-weight: 600;
+      font-size: 0.95rem;
+      flex: 1 1 auto;
+    }
+    .metric-summary .title span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .metric-summary .title-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+    }
+    .metric-summary .title-icon.placeholder {
+      visibility: hidden;
+    }
+    .metric-summary .title-icon ha-icon {
+      --mdc-icon-size: 24px;
+      color: var(--secondary-text-color);
+    }
+    .summary-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      margin-inline-start: auto;
+    }
+    .summary-actions ha-icon-button {
+      --mdc-icon-size: 20px;
+      color: var(--error-color);
+      --mdc-icon-button-ink-color: var(--error-color);
+    }
+    .metric-content {
+      display: grid;
+      gap: 12px;
+      padding: 0 16px 16px;
+    }
+    .remove-metric {
+      justify-self: start;
+      color: var(--error-color);
+    }
+    ha-button.add-metric {
+      justify-self: end;
+    }
   `;
 
   static get properties() {
@@ -40,6 +155,7 @@ export class HaSolarCardEditor extends LitElement {
     super();
     this.config = { type: 'custom:solar-card' } as SolarCardConfig;
     this._hass = null;
+    this._expandedMetricIds = new Set();
   }
 
   set hass(hass: Hass) {
@@ -69,17 +185,9 @@ export class HaSolarCardEditor extends LitElement {
       },
       { name: 'image_url', selector: { text: {} } },
     ];
-    const today = [
-      { name: 'yield_today_entity', selector: { entity: { domain: 'sensor', device_class: 'energy' } } },
-      { name: 'grid_consumption_today_entity', selector: { entity: { domain: 'sensor', device_class: 'energy' } } },
-      { name: 'battery_percentage_entity', selector: { entity: { domain: 'sensor', device_class: 'battery' } } },
-      { name: 'inverter_state_entity', selector: { entity: { domain: 'sensor' } } },
-    ];
     const totals = [
       { name: 'total_yield_entity', selector: { entity: { domain: 'sensor', device_class: 'energy' } } },
       { name: 'total_grid_consumption_entity', selector: { entity: { domain: 'sensor', device_class: 'energy' } } },
-      { name: 'battery_capacity_entity', selector: { entity: { domain: 'sensor' } } },
-      { name: 'inverter_mode_entity', selector: { entity: { domain: 'sensor' } } },
     ];
     // Weather forecast section
     const weatherToggle = [
@@ -112,7 +220,7 @@ export class HaSolarCardEditor extends LitElement {
     const sankey = [
       { name: 'show_energy_flow', selector: { boolean: {} } },
     ];
-    return { overview, today, totals, weatherToggle, weatherOptions, topDevicesToggle, topDevicesOptions, trend, sankey };
+    return { overview, totals, weatherToggle, weatherOptions, topDevicesToggle, topDevicesOptions, trend, sankey };
   }
 
   render() {
@@ -131,18 +239,7 @@ export class HaSolarCardEditor extends LitElement {
           ></ha-form>
         </div>
         <div class="section">
-          <h3>Today</h3>
-          <ha-form
-            .hass=${this._hass}
-            .data=${this.config}
-            .schema=${schemas.today}
-            .computeLabel=${this._computeLabel}
-            .computeHelper=${this._computeHelper}
-            @value-changed=${this._valueChanged}
-          ></ha-form>
-        </div>
-        <div class="section">
-          <h3>Totals & Settings</h3>
+          <h3>Production and consumption</h3>
           <ha-form
             .hass=${this._hass}
             .data=${this.config}
@@ -151,6 +248,10 @@ export class HaSolarCardEditor extends LitElement {
             .computeHelper=${this._computeHelper}
             @value-changed=${this._valueChanged}
           ></ha-form>
+        </div>
+        <div class="section">
+          <h3>Custom metrics</h3>
+          ${this._renderTotalsMetricsSection()}
         </div>
         <div class="section">
           <h3>Weather forecast</h3>
@@ -224,9 +325,267 @@ export class HaSolarCardEditor extends LitElement {
     `;
   }
 
+  private _renderTotalsMetricsSection() {
+    const hasCustomMetrics = Array.isArray(this.config?.totals_metrics);
+    const metrics = hasCustomMetrics ? this._getMetricsForEditor() : [];
+    this._syncExpandedMetricIds(metrics);
+    const maxReached = metrics.length >= HaSolarCardEditor.MAX_METRICS;
+    const showEmpty = metrics.length === 0;
+    return html`
+      <div class="metrics-editor">
+        ${metrics.length
+          ? html`<ha-sortable
+              .disabled=${metrics.length < 2}
+              draggable-selector=".metric-item"
+              handle-selector=".metric-handle"
+              @item-moved=${this._onMetricReorder}
+            >
+              <div class="metrics-list">
+                ${metrics.map((metric, index) => this._renderMetricItem(metric, index))}
+              </div>
+            </ha-sortable>`
+          : nothing}
+        ${showEmpty ? html`<div class="metrics-empty">${localize('editor.metrics_empty')}</div>` : nothing}
+        <ha-button class="add-metric" @click=${this._handleAddMetric} .disabled=${maxReached}>
+          <ha-icon slot="start" icon="mdi:plus"></ha-icon>
+          ${localize('editor.add_metric')}
+        </ha-button>
+      </div>
+    `;
+  }
+
+  private _renderMetricItem(metric: SolarCardTotalsMetric, index: number) {
+    const schema = this._metricFormSchema;
+    const metricId = metric.id || `metric-${index + 1}`;
+    const expanded = this._expandedMetricIds.has(metricId);
+    const title = this._metricTitle(metric, index);
+    return html`
+      <ha-expansion-panel
+        class="metric-item"
+        .expanded=${expanded}
+        data-metric-id=${metricId}
+        @expanded-changed=${this._onMetricExpandedChanged}
+      >
+        <div slot="header" class="metric-summary">
+          <div
+            class="metric-handle"
+            role="button"
+            aria-label=${localize('editor.reorder_metric')}
+            title=${localize('editor.reorder_metric')}
+            @click=${this._onHandleClick}
+          >
+            <ha-icon icon="mdi:drag"></ha-icon>
+          </div>
+          <span class="title">
+            <span class="title-icon ${metric.icon ? '' : 'placeholder'}">
+              ${metric.icon ? html`<ha-icon icon="${metric.icon}"></ha-icon>` : nothing}
+            </span>
+            <span>${title}</span>
+          </span>
+          <div class="summary-actions">
+            <ha-icon-button
+              class="remove-icon"
+              data-index=${index}
+              .path=${mdiDelete}
+              .label=${localize('editor.remove_metric')}
+              @click=${this._onMetricDelete}
+            ></ha-icon-button>
+          </div>
+        </div>
+        <div class="metric-content">
+          <ha-form
+            .hass=${this._hass}
+            .data=${metric}
+            .schema=${schema}
+            .computeLabel=${this._computeMetricFieldLabel}
+            data-index=${index}
+            @value-changed=${this._onMetricValueChanged}
+          ></ha-form>
+        </div>
+      </ha-expansion-panel>
+    `;
+  }
+
+  private _metricTitle(metric: SolarCardTotalsMetric, index: number) {
+    const label = typeof metric.label === 'string' ? metric.label.trim() : '';
+    if (label) return label;
+    const entityId = typeof metric.entity === 'string' ? metric.entity.trim() : '';
+    if (entityId) {
+      const friendly = this._hass?.states?.[entityId]?.attributes?.friendly_name;
+      if (friendly && typeof friendly === 'string') return friendly;
+      const [, namePart] = entityId.split('.', 2);
+      return namePart ? namePart.replace(/_/g, ' ') : entityId;
+    }
+    return `${localize('card.total_metric')} ${index + 1}`;
+  }
+
+  private _getMetricsForEditor(): SolarCardTotalsMetric[] {
+    const cfgMetrics = this.config?.totals_metrics;
+    if (!Array.isArray(cfgMetrics)) return [];
+    return cfgMetrics.map((metric, idx) => this._normalizeMetric(metric, idx));
+  }
+
+  private _normalizeMetric(metric: SolarCardTotalsMetric | undefined, index: number): SolarCardTotalsMetric {
+    const entity = typeof metric?.entity === 'string' && metric.entity ? metric.entity : undefined;
+    const rawLabel = typeof metric?.label === 'string' ? metric.label : '';
+    const label = rawLabel.trim() ? rawLabel : undefined;
+    const unit = typeof metric?.unit === 'string' && metric.unit ? metric.unit : undefined;
+    const icon = typeof metric?.icon === 'string' && metric.icon ? metric.icon : undefined;
+    const baseId =
+      typeof metric?.id === 'string' && metric.id
+        ? metric.id
+        : entity
+          ? entity
+          : `metric-${index + 1}`;
+    const normalized: SolarCardTotalsMetric = { id: baseId };
+    if (entity) normalized.entity = entity;
+    if (label) normalized.label = label;
+    if (unit) normalized.unit = unit;
+    if (icon) normalized.icon = icon;
+    return normalized;
+  }
+
+  private _syncExpandedMetricIds(metrics: SolarCardTotalsMetric[]) {
+    const validIds = new Set(
+      metrics.map((metric) => (typeof metric.id === 'string' && metric.id ? metric.id : '')).filter(Boolean),
+    );
+    let changed = false;
+    for (const id of Array.from(this._expandedMetricIds)) {
+      if (!validIds.has(id)) {
+        this._expandedMetricIds.delete(id);
+        changed = true;
+      }
+    }
+    if (changed) {
+      this._expandedMetricIds = new Set(this._expandedMetricIds);
+    }
+  }
+
+  private _prepareMetricsForMutation(): SolarCardTotalsMetric[] {
+    return this._getMetricsForEditor().map((metric) => ({ ...metric }));
+  }
+
+  private _commitMetrics(metrics: SolarCardTotalsMetric[]) {
+    const sanitized = metrics.map((metric, index) => this._sanitizeMetric(metric, index));
+    this._applyConfigUpdate({ totals_metrics: sanitized.length ? sanitized : [] });
+  }
+
+  private _sanitizeMetric(metric: SolarCardTotalsMetric, index: number): SolarCardTotalsMetric {
+    const entity = typeof metric.entity === 'string' && metric.entity.trim() ? metric.entity.trim() : undefined;
+    const rawLabel = typeof metric.label === 'string' ? metric.label : '';
+    const label = rawLabel.trim() ? rawLabel : undefined;
+    const unit = typeof metric.unit === 'string' && metric.unit.trim() ? metric.unit.trim() : undefined;
+    const icon = typeof metric.icon === 'string' && metric.icon.trim() ? metric.icon.trim() : undefined;
+    const baseId =
+      typeof metric.id === 'string' && metric.id
+        ? metric.id
+        : entity
+          ? entity
+          : this._generateMetricId(index);
+    const result: SolarCardTotalsMetric = { id: baseId };
+    if (entity) result.entity = entity;
+    if (label) result.label = label;
+    if (unit) result.unit = unit;
+    if (icon) result.icon = icon;
+    return result;
+  }
+
+  private _generateMetricId(seed: number) {
+    try {
+      if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+        return (crypto as Crypto).randomUUID();
+      }
+    } catch (_e) {
+      /* ignore */
+    }
+    return `metric-${Date.now()}-${seed}`;
+  }
+
+  private _handleAddMetric = (ev: Event) => {
+    ev.stopPropagation();
+    const metrics = this._prepareMetricsForMutation();
+    if (metrics.length >= HaSolarCardEditor.MAX_METRICS) return;
+    const newId = this._generateMetricId(metrics.length);
+    metrics.push({ id: newId });
+    const expanded = new Set(this._expandedMetricIds);
+    expanded.add(newId);
+    this._expandedMetricIds = expanded;
+    this._commitMetrics(metrics);
+  };
+
+  private _onMetricValueChanged = (ev: CustomEvent) => {
+    ev.stopPropagation();
+    const form = ev.currentTarget as HTMLElement | null;
+    const index = Number(form?.dataset?.index ?? -1);
+    if (index < 0) return;
+    const metrics = this._prepareMetricsForMutation();
+    if (!metrics[index]) return;
+    metrics[index] = { ...metrics[index], ...(ev.detail?.value || {}) };
+    this._commitMetrics(metrics);
+  };
+
+  private _onMetricDelete = (ev: Event) => {
+    ev.stopPropagation();
+    const index = Number((ev.currentTarget as HTMLElement)?.dataset?.index ?? -1);
+    if (index < 0) return;
+    const metrics = this._prepareMetricsForMutation();
+    if (!metrics[index]) return;
+    metrics.splice(index, 1);
+    this._commitMetrics(metrics);
+  };
+
+  private _onMetricReorder = (ev: CustomEvent<{ oldIndex: number; newIndex: number }>) => {
+    ev.stopPropagation();
+    const detail = ev.detail;
+    if (!detail) return;
+    const oldIndex = Number.isFinite(detail.oldIndex) ? detail.oldIndex : -1;
+    const newIndex = Number.isFinite(detail.newIndex) ? detail.newIndex : -1;
+    if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return;
+    const metrics = this._prepareMetricsForMutation();
+    if (!metrics.length || oldIndex >= metrics.length) return;
+    const [moved] = metrics.splice(oldIndex, 1);
+    if (!moved) return;
+    const targetIndex = Math.min(newIndex, metrics.length);
+    metrics.splice(targetIndex, 0, moved);
+    this._commitMetrics(metrics);
+  };
+
+  private _onMetricExpandedChanged = (ev: CustomEvent<{ expanded: boolean }>) => {
+    ev.stopPropagation();
+    const panel = ev.currentTarget as HTMLElement | null;
+    const metricId = panel?.dataset?.metricId;
+    if (!metricId) return;
+    const expanded = Boolean(ev.detail?.expanded);
+    const next = new Set(this._expandedMetricIds);
+    if (expanded) {
+      next.add(metricId);
+    } else {
+      next.delete(metricId);
+    }
+    this._expandedMetricIds = next;
+  };
+
+  private _computeMetricFieldLabel = (schema) => {
+    const map: Record<string, string> = {
+      label: localize('editor.metric_label'),
+      entity: localize('editor.metric_entity'),
+      unit: localize('editor.metric_unit'),
+      icon: localize('editor.metric_icon'),
+    };
+    return map[schema.name] || schema.name;
+  };
+
+  private _onHandleClick = (ev: Event) => {
+    ev.stopPropagation();
+  };
+
   _valueChanged = (ev) => {
     ev.stopPropagation();
-    const newConfig = { ...this.config, ...ev.detail.value };
+    this._applyConfigUpdate(ev.detail.value);
+  };
+
+  private _applyConfigUpdate(partial: Partial<SolarCardConfig>) {
+    const newConfig = { ...this.config, ...partial };
     this.config = newConfig;
     this.dispatchEvent(
       new CustomEvent('config-changed', {
@@ -235,7 +594,7 @@ export class HaSolarCardEditor extends LitElement {
         composed: true,
       }),
     );
-  };
+  }
 
   _computeLabel = (schema) => {
     const labelMap = {
@@ -247,14 +606,8 @@ export class HaSolarCardEditor extends LitElement {
       show_solar_forecast: 'Show solar forecast panel',
       weather_entity: 'Weather entity (optional)',
       solar_forecast_today_entity: 'Solar forecast today entity (kWh, optional)',
-      yield_today_entity: 'Yield today entity (kWh)',
-      grid_consumption_today_entity: 'Grid consumption today entity (kWh)',
-      battery_percentage_entity: 'Battery percentage entity (%)',
-      inverter_state_entity: 'Inverter state entity (text)',
       total_yield_entity: 'Total yield entity (kWh)',
       total_grid_consumption_entity: 'Total grid consumption entity (kWh)',
-      battery_capacity_entity: 'Battery capacity entity (kWh)',
-      inverter_mode_entity: 'Inverter mode entity (text sensor)',
       image_url: 'Image URL (optional)',
       trend_graph_entities: 'Trend graph entities (multiple sensors)',
       trend_graph_hours_to_show: 'Trend graph hours (default 24)',
@@ -264,9 +617,6 @@ export class HaSolarCardEditor extends LitElement {
 
   _computeHelper = (schema) => {
     const helperMap = {
-      yield_today_entity: "Optional. Leave empty to compute from 'Total yield' using today's history (00:00 → now).",
-      grid_consumption_today_entity:
-        "Optional. Leave empty to compute from 'Total grid consumption' using today's history (00:00 → now).",
       show_energy_flow: 'Adds the built-in Energy Flow (Sankey) graph below this card (requires Energy configuration).',
       show_top_devices:
         'Adds a single-row list of top-consuming devices from Energy preferences (requires Energy configuration).',

--- a/src/types/solar-card-config.ts
+++ b/src/types/solar-card-config.ts
@@ -11,15 +11,18 @@ export interface SolarCardConfig extends LovelaceCardConfig {
   show_solar_forecast?: boolean;
   weather_entity?: string;
   solar_forecast_today_entity?: string;
-  yield_today_entity?: string;
-  grid_consumption_today_entity?: string;
-  battery_percentage_entity?: string;
-  inverter_state_entity?: string;
   total_yield_entity?: string;
   total_grid_consumption_entity?: string;
-  battery_capacity_entity?: string;
-  inverter_mode_entity?: string;
+  totals_metrics?: SolarCardTotalsMetric[];
   trend_graph_entities?: string[];
+}
+
+export interface SolarCardTotalsMetric {
+  id?: string;
+  entity?: string;
+  label?: string;
+  unit?: string;
+  icon?: string;
 }
 
 export interface DisplayValue {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,36 +2,35 @@ import type { Hass } from '../types/ha';
 import type { SolarCardConfig } from '../types/solar-card-config';
 
 export function normalizeConfig(config: SolarCardConfig): SolarCardConfig {
-  const normalized: SolarCardConfig = {
-    ...config,
-    type: config.type ?? 'custom:solar-card',
-    production_entity: config.production_entity ?? config.yield_today_entity ?? '',
-    current_consumption_entity: config.current_consumption_entity ?? '',
-    image_url: config.image_url ?? '',
-    show_energy_flow: config.show_energy_flow ?? false,
-    show_top_devices: config.show_top_devices ?? false,
-    top_devices_max: Math.min(Math.max(parseInt(String(config.top_devices_max ?? 4), 10) || 4, 1), 8),
-    show_solar_forecast: config.show_solar_forecast ?? false,
-    weather_entity: config.weather_entity ?? '',
-    solar_forecast_today_entity: config.solar_forecast_today_entity ?? '',
-    trend_graph_entities: Array.isArray(config.trend_graph_entities)
-      ? config.trend_graph_entities
-      : [],
-    yield_today_entity: config.yield_today_entity ?? '',
-    grid_consumption_today_entity: config.grid_consumption_today_entity ?? '',
-    battery_percentage_entity: config.battery_percentage_entity ?? '',
-    inverter_state_entity: config.inverter_state_entity ?? '',
-    total_yield_entity: config.total_yield_entity ?? '',
-    total_grid_consumption_entity: config.total_grid_consumption_entity ?? '',
-    battery_capacity_entity: config.battery_capacity_entity ?? '',
-    inverter_mode_entity: config.inverter_mode_entity ?? '',
-  } satisfies SolarCardConfig;
+  const normalized: Record<string, any> = { ...config };
+  const legacyProduction = (config as Record<string, any>)?.yield_today_entity ?? '';
+  normalized.type = config.type ?? 'custom:solar-card';
+  normalized.production_entity = config.production_entity ?? legacyProduction ?? '';
+  normalized.current_consumption_entity = config.current_consumption_entity ?? '';
+  normalized.image_url = config.image_url ?? '';
+  normalized.show_energy_flow = config.show_energy_flow ?? false;
+  normalized.show_top_devices = config.show_top_devices ?? false;
+  normalized.top_devices_max = Math.min(Math.max(parseInt(String(config.top_devices_max ?? 4), 10) || 4, 1), 8);
+  normalized.show_solar_forecast = config.show_solar_forecast ?? false;
+  normalized.weather_entity = config.weather_entity ?? '';
+  normalized.solar_forecast_today_entity = config.solar_forecast_today_entity ?? '';
+  normalized.trend_graph_entities = Array.isArray(config.trend_graph_entities)
+    ? config.trend_graph_entities
+    : [];
+  normalized.total_yield_entity = config.total_yield_entity ?? '';
+  normalized.total_grid_consumption_entity = config.total_grid_consumption_entity ?? '';
+  delete normalized.yield_today_entity;
+  delete normalized.grid_consumption_today_entity;
+  delete normalized.battery_percentage_entity;
+  delete normalized.inverter_state_entity;
+  delete normalized.battery_capacity_entity;
+  delete normalized.inverter_mode_entity;
 
   if (!normalized.production_entity || !normalized.current_consumption_entity) {
     throw new Error('Solar Card: production_entity and current_consumption_entity are required.');
   }
 
-  return normalized;
+  return normalized as SolarCardConfig;
 }
 
 function buildCandidateLists(
@@ -95,13 +94,7 @@ export function stubConfig(
     weather_entity: '',
     solar_forecast_today_entity: '',
     trend_graph_entities: [],
-    yield_today_entity: '',
-    grid_consumption_today_entity: '',
-    battery_percentage_entity: '',
-    inverter_state_entity: '',
     total_yield_entity: '',
     total_grid_consumption_entity: '',
-    battery_capacity_entity: '',
-    inverter_mode_entity: '',
   } satisfies SolarCardConfig;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,6 +448,11 @@
   dependencies:
     "@lit-labs/ssr-dom-shim" "^1.4.0"
 
+"@mdi/js@7.4.47":
+  version "7.4.47"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-7.4.47.tgz#7d8a4edc9631bffeed80d1ec784f9beae559a76a"
+  integrity sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
## Pull Request Overview

This PR replaces fixed metric entities with a flexible custom metrics system for the solar card's totals section. The change allows users to configure up to 8 custom metrics with drag-and-drop ordering, custom labels, icons, and units instead of being limited to predefined entity fields.

Key changes:

- Removed hardcoded entity fields (yield_today_entity, grid_consumption_today_entity, battery_percentage_entity, etc.)
- Added configurable totals_metrics array with custom labels, icons, and unit overrides
- Implemented visual editor with drag-and-drop reordering for custom metrics


<img width="466" height="511" alt="imagen" src="https://github.com/user-attachments/assets/947ed56a-2fa0-42e2-b69f-f0a824efb76a" />
