### PR TITLE
alternate metrics when grid shrinks to 2 columns

### DIFF
--- a/src/solar-card.ts
+++ b/src/solar-card.ts
@@ -966,12 +966,12 @@ class HaSolarCard extends LitElement {
       ),
     ];
     const columns = Math.min(Math.max(items.length, 1), 4);
-    const grouped: any = items.reduce((acc: any, item, idx) => {
+    const grouped: Array<Array<unknown>> = items.reduce((acc: Array<Array<unknown>>, item, idx) => {
       const col = idx % columns;
       if (!acc[col]) acc[col] = [];
       acc[col].push(item);
       return acc;
-    }, [] as unknown[][]);
+    }, []);
     return grouped.length
       ? html` <div class="metrics-grid" style="--metrics-cols: ${columns}">
           ${grouped.map((columnItems) => html`<div class="metric-column">${columnItems}</div>`)}

--- a/src/solar-card.ts
+++ b/src/solar-card.ts
@@ -328,6 +328,9 @@ class HaSolarCard extends LitElement {
       gap: 12px;
       align-items: start;
     }
+    .metrics-grid .metric-wrapper {
+      display: contents;
+    }
     .metrics-grid .metric {
       min-width: 0;
     }
@@ -336,6 +339,10 @@ class HaSolarCard extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
       display: block;
+    }
+    .metric-column {
+      display: grid;
+      gap: 24px;
     }
 
     /* Stack sections on narrower screens */
@@ -959,7 +966,17 @@ class HaSolarCard extends LitElement {
       ),
     ];
     const columns = Math.min(Math.max(items.length, 1), 4);
-    return html` <div class="metrics-grid" style="--metrics-cols: ${columns}">${items}</div>`;
+    const grouped: any = items.reduce((acc: any, item, idx) => {
+      const col = idx % columns;
+      if (!acc[col]) acc[col] = [];
+      acc[col].push(item);
+      return acc;
+    }, [] as unknown[][]);
+    return grouped.length
+      ? html` <div class="metrics-grid" style="--metrics-cols: ${columns}">
+          ${grouped.map((columnItems) => html`<div class="metric-column">${columnItems}</div>`)}
+        </div>`
+      : nothing;
   }
 
   private _renderForecastPanel(forecast: {


### PR DESCRIPTION
### Pull request overview

This PR implements an alternate metric layout when the grid shrinks to 2 columns, improving the visual presentation and spacing of metrics in constrained layouts. The changes reorganize metrics into column-based grouping with enhanced styling for better readability.

- Modifies metric grid layout to use column-based grouping instead of direct item placement
- Implements logic to distribute metrics evenly across columns using modulo grouping


<img width="768" height="160" alt="imagen" src="https://github.com/user-attachments/assets/7cf1f413-7490-45b2-a2d0-fb6d2cd06bd6" />

<img width="499" height="241" alt="imagen" src="https://github.com/user-attachments/assets/e87d48f8-31cb-4633-9333-424764ae6d22" />
