### PR TITLE
fix: support stat_rate field for device power consumption pills

### DIFF
--- a/src/services/devices.ts
+++ b/src/services/devices.ts
@@ -66,15 +66,27 @@ export async function buildDevicePowerMapping(
     const statId = dev.stat_consumption;
     if (!statId || !statId.includes('.')) continue;
     const entry = reg.find((e) => e.entity_id === statId);
-    const deviceId = entry?.device_id;
+    const powerEntry = dev.stat_rate
+      ? reg.find((e) => e.entity_id === dev.stat_rate)
+      : undefined;
+    const deviceId = entry?.device_id ?? powerEntry?.device_id;
     if (!deviceId) continue;
-    const candidates = (byDevice[deviceId] || []).filter((eid) => {
-      const st = states[eid];
+    if (dev.stat_rate) {
+      const st = states[dev.stat_rate];
       const dc = st?.attributes?.device_class;
       const unit = st?.attributes?.unit_of_measurement || '';
-      return dc === 'power' && /k?W/i.test(unit);
-    });
-    if (candidates.length) devicePowerMap[statId] = candidates;
+      if (dc === 'power' && /k?W/i.test(unit)) {
+        devicePowerMap[statId] = [dev.stat_rate];
+      }
+    } else {
+      const candidates = (byDevice[deviceId] || []).filter((eid) => {
+        const st = states[eid];
+        const dc = st?.attributes?.device_class;
+        const unit = st?.attributes?.unit_of_measurement || '';
+        return dc === 'power' && /k?W/i.test(unit);
+      });
+      if (candidates.length) devicePowerMap[statId] = candidates;
+    }
     statToDeviceId[statId] = deviceId;
     deviceEntitiesMap[deviceId] = byDevice[deviceId] || [];
   }

--- a/src/types/ha.ts
+++ b/src/types/ha.ts
@@ -46,6 +46,7 @@ export interface DeviceRegistryEntry {
 
 export interface DeviceConsumptionPref {
   stat_consumption: string;
+  stat_rate?: string;
   name?: string;
 }
 


### PR DESCRIPTION
## Problem

Since Home Assistant 2024.x, the `energy/get_prefs` WebSocket API returns a `stat_rate` field alongside `stat_consumption` for each device in `device_consumption`. `stat_rate` contains the entity ID of the **power sensor** (W), while `stat_consumption` holds the **energy sensor** (kWh).

The card only read `stat_consumption` and used it to look up a `device_id` in the entity registry. This silently broke device pills for a common setup:

- Energy sensor created via `platform: integration` (Riemann sum) **without** a `unique_id` → not in the entity registry → no `device_id` → `buildDevicePowerMapping` skips the device entirely with `if (!deviceId) continue`
- The power sensor (`stat_rate`) **is** properly registered with a device, but was never consulted

Result: device pills never appear even though the sensor is active, has a device, and is consuming power.

## Fix

- Add `stat_rate?: string` to the `DeviceConsumptionPref` type
- When `stat_rate` is present, use it **directly** as the power candidate (no need to scan all device entities via `byDevice`)
- Derive `device_id` from the `stat_rate` entity as a fallback when `stat_consumption` has no registry entry

## How to reproduce

1. Add a device to the HA Energy Dashboard with a power sensor configured in "Device power consumption"
2. Use a `platform: integration` sensor (without `unique_id`) as the energy consumption sensor
3. Enable `show_top_devices: true` — the device pill never appears despite the sensor reporting > 0 W

## Testing

Verified via browser console logging that `raw_dev` contains `{ stat_consumption: "sensor.x_energy", stat_rate: "sensor.x_power" }` and that the pill now correctly appears after this fix.